### PR TITLE
Switch dashboard streams to clean/preview endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ required for upgrades or fresh installs.
 - **Dashboard history API**: Aggregated metrics are available via `/api/dashboard/stats?range=7d` where `range` may be `today`, `7d`, or `this_month`.
 - **Debug stats**: Visit `/debug` to monitor raw SSE data, connection status, and camera backend info.
 - **Debug overlays**: Toggle line, ID, and count overlays from the Settings page.
-- **Live feed optimization**: Dashboard streams the raw camera feed via `/stream/{cam_id}?raw=1` while analysis runs separately.
+- **Live feed optimization**: Dashboard streams the raw camera feed via `/stream/clean/{cam_id}` while analysis runs separately.
 - **Per-camera resolution**: Choose 480p, 720p, 1080p, or original when adding a camera.
 - **Camera status**: Online/offline indicators appear in the Cameras page for quick troubleshooting.
 - **Secure logins**: User passwords are stored as PBKDF2 hashes and verified using passlib.

--- a/docs/modules/modules_overlay.md
+++ b/docs/modules/modules_overlay.md
@@ -13,7 +13,7 @@ None
 - **draw_overlays(frame, tracks, show_ids, show_track_lines, show_lines, line_orientation, line_ratio, show_counts, in_count, out_count, face_boxes=None)** - Draw tracking debug overlays and optional face bounding boxes on the frame.
 
 ## Inputs and Outputs
-Refer to function signatures above for inputs and outputs. When any debug flag (lines, IDs, track lines, counts, or face boxes) is enabled the processed frame is streamed via `/stream/{cam_id}`; otherwise the dashboard requests `/stream/{cam_id}?raw=1`. Client-side scripts update the feed URL when these settings change.
+Refer to function signatures above for inputs and outputs. When any debug flag (lines, IDs, track lines, counts, or face boxes) is enabled the processed frame is streamed via `/stream/preview/{cam_id}`; otherwise the dashboard requests `/stream/clean/{cam_id}`. Client-side scripts update the feed URL when these settings change.
 
 ## Redis Keys
 None

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -268,8 +268,8 @@ if (typeof document !== "undefined" && !globalThis.__TEST__) {
       const debug = debugIds.some((id) => document.getElementById(id)?.checked);
       feeds.forEach((img) => {
         const cam = getLastPathSegment(img.src);
-        const base = "/stream/";
-        const target = debug ? base + cam : base + cam + "?raw=1";
+        const base = debug ? "/stream/preview/" : "/stream/clean/";
+        const target = base + cam;
         if (img.src.endsWith(target)) return;
         img.src = target;
       });

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -172,7 +172,7 @@
                         {{cam.name}}
                       </div>
                       {% set debug_mode = cfg['show_lines'] or cfg['show_ids'] or cfg['show_track_lines'] or cfg['show_counts'] or cfg['show_face_boxes'] or cfg['enable_face_counting'] %}
-                      {% set stream_url = '/stream/preview/' ~ cam.id ~ ('' if debug_mode else '?raw=1') %}
+                      {% set stream_url = ('/stream/preview/' if debug_mode else '/stream/clean/') ~ cam.id %}
                       <img src="{{ stream_url }}" class="card-img-top feed-img" alt="feed" data-cam="{{cam.id}}">
                     </div>
                 </div>
@@ -275,7 +275,7 @@
         </div>
         {% if cameras %}
         {% set cam = cameras[0] %}
-        {% set stream_url = '/stream/preview/' ~ cam.id ~ ('' if debug_mode else '?raw=1') %}
+        {% set stream_url = ('/stream/preview/' if debug_mode else '/stream/clean/') ~ cam.id %}
         <div class="col-md-2">
             <img src="{{ stream_url }}" class="img-fluid feed-img" alt="feed" data-cam="{{ cam.id }}">
         </div>


### PR DESCRIPTION
## Summary
- Choose `/stream/clean/{cam.id}` when no debug overlays are active and `/stream/preview/{cam.id}` when they are
- Remove obsolete `?raw=1` references and update settings feed toggling
- Refresh docs to describe new stream endpoints

## Testing
- `pre-commit run --files templates/dashboard.html static/js/settings.js docs/modules/modules_overlay.md README.md`
- `pytest` *(fails: ImportError: cannot import name 'visitor_db' from 'modules')*


------
https://chatgpt.com/codex/tasks/task_e_68b9225749d8832ab6299daf9c6854f5