### PR TITLE
chore: remove unused blur score

### DIFF
--- a/docs/modules/modules_visitor_worker.md
+++ b/docs/modules/modules_visitor_worker.md
@@ -11,7 +11,7 @@ disabled.
 - **VisitorWorker** - Continuously process frames for visitor recognition.
 
 ## Key Functions
-- **_blur_score(img)** - 
+None
 
 ## Inputs and Outputs
 Refer to function signatures above for inputs and outputs.

--- a/workers/visitor/recognizer.py
+++ b/workers/visitor/recognizer.py
@@ -4,14 +4,9 @@ import json
 from collections import deque
 from typing import Dict, Optional
 
-import cv2
 import numpy as np
+
 from config import FACE_THRESHOLDS
-
-
-def _blur_score(img: np.ndarray) -> float:
-    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-    return float(cv2.Laplacian(gray, cv2.CV_64F).var())
 
 
 class FaceRecognizer:
@@ -36,9 +31,7 @@ class FaceRecognizer:
     def identify(self, emb: np.ndarray) -> Optional[str]:
         if not self.known:
             return None
-        thresh = self.cfg.get(
-            "face_match_thresh", FACE_THRESHOLDS.recognition_match
-        )
+        thresh = self.cfg.get("face_match_thresh", FACE_THRESHOLDS.recognition_match)
         names = list(self.known.keys())
         arr = np.stack([self.known[n] for n in names])
         dists = np.linalg.norm(arr - emb, axis=1)


### PR DESCRIPTION
## Summary
- drop unused `_blur_score` helper and `cv2` import from visitor recognizer
- remove `_blur_score` from visitor worker docs

## Testing
- `pre-commit run --files workers/visitor/recognizer.py docs/modules/modules_visitor_worker.md`
- `pytest` *(fails: FileNotFoundError, TypeError, AttributeError, RuntimeError, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b9346ccc1c832a824ec3e41368a115