### PR TITLE
Validate YOLO model path

### DIFF
--- a/modules/model_registry.py
+++ b/modules/model_registry.py
@@ -54,12 +54,16 @@ def get_yolo(path: str, device: "torch.device | str | None" = None) -> YOLO:
     """Return a cached YOLO model for ``path`` on ``device``."""
     if YOLO is None:
         raise RuntimeError("YOLO not available")
+    if not path:
+        raise ValueError("Model path must be provided")
     dev = _resolve_device(device)
     key = (path, dev.type)
     model = _yolo_models.get(key)
     if model is None:
         _log_mem(f"Before loading YOLO model {path}", dev)
         model = YOLO(path)
+        if not hasattr(getattr(model, "model", None), "to"):
+            raise RuntimeError(f"Invalid YOLO model for path: {path}")
         model.model.to(dev)
         if dev.type == "cuda":
             model.model.half()

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,13 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from modules import model_registry
+
+
+def test_get_yolo_requires_path(monkeypatch):
+    monkeypatch.setattr(model_registry, "YOLO", object)
+    with pytest.raises(ValueError, match="Model path must be provided"):
+        model_registry.get_yolo("")


### PR DESCRIPTION
## Summary
- guard against empty or invalid YOLO model paths
- add regression test for missing model path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b96675b90c832ab4589aa0e928abdc