### PR TITLE
feat: add alerts API and camera creation script

### DIFF
--- a/routers/__init__.py
+++ b/routers/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "reports",
     "ppe_reports",
     "settings",
+    "api_alerts",
     "api_identities",
     "blueprints",
     "mcp",

--- a/routers/api_alerts.py
+++ b/routers/api_alerts.py
@@ -1,0 +1,37 @@
+"""API endpoints for recent alert data."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from loguru import logger
+
+from utils.deps import get_redis
+
+router = APIRouter()
+
+ALERTS_KEY = "alerts:recent"
+
+
+@router.get("/api/alerts/recent")
+async def get_recent_alerts(
+    limit: int = Query(20, ge=1, le=100),
+    redis=Depends(get_redis),
+):
+    """Return a list of recent alert messages."""
+    try:
+        raw = redis.lrange(ALERTS_KEY, -limit, -1) if redis else []
+        alerts: list = []
+        for item in raw:
+            if isinstance(item, (bytes, bytearray)):
+                item = item.decode()
+            try:
+                alerts.append(json.loads(item))
+            except Exception:
+                alerts.append(item)
+        return alerts
+    except Exception:
+        logger.exception("Failed to fetch alerts")
+        return JSONResponse({"error": "unavailable"}, status_code=500)

--- a/routers/blueprints.py
+++ b/routers/blueprints.py
@@ -4,16 +4,9 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from . import alerts, api_identities, auth
-
+from . import alerts, api_alerts, api_identities, auth
 from . import cameras as cam_routes
-from . import (
-    config_api,
-    dashboard,
-    detections,
-    feedback,
-    health,
-)
+from . import config_api, dashboard, detections, feedback, health
 from . import help as help_pages
 from . import mcp, ppe_reports, profile, reports, rtsp, settings
 from .admin import users as admin_users
@@ -28,6 +21,7 @@ MODULES = [
     alerts,
     auth,
     admin_users,
+    api_alerts,
     api_identities,
     health,
     profile,

--- a/static/js/camera_create.js
+++ b/static/js/camera_create.js
@@ -1,0 +1,102 @@
+import { showFieldError, clearFieldError } from './validation.js';
+
+export function initCameraForm() {
+  const form = document.getElementById('cameraForm');
+  if (!form) return;
+
+  const nameInput = document.getElementById('name');
+  const urlInput = document.getElementById('url');
+  const previewBtn = document.getElementById('testPreview');
+  const saveBtn = document.getElementById('saveBtn');
+  const saveActivateBtn = document.getElementById('saveActivateBtn');
+  const previewImg = document.getElementById('previewImg');
+  const previewLog = document.getElementById('previewLog');
+  const modal = new bootstrap.Modal(document.getElementById('previewModal'));
+
+  function getPayload() {
+    return {
+      name: nameInput.value.trim(),
+      url: urlInput.value.trim(),
+      type: document.getElementById('type').value,
+      profile: document.getElementById('profile').value,
+      orientation: document.getElementById('orientation').value,
+      resolution: document.getElementById('resolution').value,
+      transport: document.getElementById('transport').value,
+      ppe: document.getElementById('ppe').checked,
+      counting: document.getElementById('inout_count').checked,
+      reverse: document.getElementById('reverse').checked,
+      show: document.getElementById('show').checked,
+    };
+  }
+
+  function validate() {
+    let ok = true;
+    if (!nameInput.value.trim()) {
+      showFieldError(nameInput, 'Required');
+      ok = false;
+    } else {
+      clearFieldError(nameInput);
+    }
+    if (!urlInput.value.trim()) {
+      showFieldError(urlInput, 'Required');
+      ok = false;
+    } else {
+      clearFieldError(urlInput);
+    }
+    return ok;
+  }
+
+  async function submit(activate = false) {
+    if (!validate()) return;
+    const payload = getPayload();
+    if (activate) payload.enabled = true;
+    const camId = form.dataset.camId;
+    const url = camId ? `/cameras/${camId}` : '/cameras';
+    const method = camId ? 'PUT' : 'POST';
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        window.location.href = '/cameras';
+      } else {
+        const err = await res.json().catch(() => ({}));
+        alert(err.error || 'Failed to save');
+      }
+    } catch (e) {
+      console.error('Save failed', e);
+      alert('Failed to save');
+    }
+  }
+
+  async function preview() {
+    if (!validate()) return;
+    previewImg.removeAttribute('src');
+    previewLog.textContent = '';
+    try {
+      const r = await fetch('/api/cameras/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: urlInput.value.trim() }),
+      });
+      const d = await r.json();
+      if (r.ok && d.notes) {
+        previewImg.src = d.notes;
+      } else {
+        previewLog.textContent = d.error || 'Preview failed';
+      }
+    } catch (e) {
+      console.error('Preview failed', e);
+      previewLog.textContent = 'Preview failed';
+    }
+    modal.show();
+  }
+
+  previewBtn?.addEventListener('click', preview);
+  saveBtn?.addEventListener('click', () => submit(false));
+  saveActivateBtn?.addEventListener('click', () => submit(true));
+}
+
+initCameraForm();

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1,0 +1,29 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from routers import api_alerts
+
+
+class DummyRedis:
+    def lrange(self, key, start, end):
+        return [b'{"message":"hi"}', b"plain"]
+
+
+def create_app():
+    app = FastAPI()
+    app.state.redis_client = DummyRedis()
+    app.include_router(api_alerts.router)
+    return app
+
+
+def test_recent_alerts():
+    app = create_app()
+    client = TestClient(app)
+    r = client.get("/api/alerts/recent")
+    assert r.status_code == 200
+    assert r.json() == [{"message": "hi"}, "plain"]


### PR DESCRIPTION
## Summary
- add `/api/alerts/recent` endpoint to serve latest alert messages
- wire new API router into blueprint registry
- add camera creation module for form submission and preview flow

## Testing
- `pre-commit run --files routers/api_alerts.py routers/blueprints.py routers/__init__.py static/js/camera_create.js tests/test_api_alerts.py`
- `pytest`
- manual `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b9710db1b8832a8c04852e3ee6213d