### PR TITLE
Fix startup by using default YOLO model path

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "stream_url": "http://localhost/zm/cgi-bin/nph-zms?mode=jpeg&monitor=20",
-  "person_model": "models/yolov8n.pt",
+  "person_model": "yolov8n.pt",
   "ppe_model": "",
   "plate_model": "",
   "device": "auto",


### PR DESCRIPTION
## Summary
- reference Ultralytics `yolov8n.pt` instead of missing placeholder model to avoid startup crash

## Testing
- `uvicorn app:app`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b97bb87d30832a8a3dba1ac89466e6