### PR TITLE
Log plate model path

### DIFF
--- a/modules/tracker/manager.py
+++ b/modules/tracker/manager.py
@@ -615,10 +615,10 @@ class PersonTracker:
         self.out_queue = queue.Queue(maxsize=qsize)
         log_mem("Before loading plate model")
         try:
+            plate_path = cfg.get("plate_model") or "license_plate_detector.pt"
+            logger.info(f"Plate model: {plate_path}")
             start = time.perf_counter()
-            self.model_plate = get_yolo(
-                cfg.get("plate_model", "license_plate_detector.pt"), self.device
-            )
+            self.model_plate = get_yolo(plate_path, self.device)
             self.load_durations["plate_model"] = time.perf_counter() - start
             logger.info(
                 "Plate model loaded in {:.2f}s",


### PR DESCRIPTION
## Summary
- ensure license plate model path falls back to default when unset
- log resolved plate model path during tracker initialization

## Testing
- `python - <<'PY'
import types, sys
cv2_stub = types.SimpleNamespace(COLOR_BGR2RGB=0, cvtColor=lambda frame, flag: frame, imwrite=lambda path, img: True)
sys.modules['cv2'] = cv2_stub
from unittest.mock import patch
from types import SimpleNamespace
import modules.tracker.manager as mgr

def dummy_get_yolo(path, device):
    print('dummy_get_yolo called with', path)
    return SimpleNamespace(names=['person'], model=SimpleNamespace(to=lambda dev: None, half=lambda: None))
class DummyTracker:
    def __init__(self, use_gpu_embedder):
        self.use_gpu_embedder = use_gpu_embedder
    def update_tracks(self, detections, frame=None):
        return []
class DummyRedis:
    def __init__(self):
        self.store={}
    def mget(self, keys):
        return [self.store.get(k) for k in keys]
    def mset(self, mapping):
        self.store.update(mapping)
    def zadd(self, key, mapping):
        pass
    def get(self, key):
        return self.store.get(key)

def dummy_get_sync_client(url):
    return DummyRedis()
with patch('modules.model_registry.get_yolo', dummy_get_yolo), patch.object(mgr, 'Tracker', DummyTracker), patch.object(mgr, 'get_sync_client', dummy_get_sync_client):
    from modules.tracker.manager import PersonTracker
    cfg = {
        'person_model': 'yolov8n.pt',
        'plate_model': '',
        'device': 'cpu',
        'show_lines': False,
        'show_ids': False,
        'show_track_lines': False,
        'show_counts': False,
        'show_face_boxes': False,
        'redis_url': 'redis://localhost'
    }
    tracker = PersonTracker(cam_id=1, src='dummy', classes=['person'], cfg=cfg)
    print('Initialized tracker; plate model path accounted')
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b981aa87f8832ab90dbe9684a1d935